### PR TITLE
Default publish devel tag (NPM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## From git log
 
-### v3.0.0-alpha.2 (2022-04-03)
+### v3.0.0-alpha.3-dev.1 (2022-04-03)
 
+- [Default to publishing 'devel' version not 'latest'](https://github.com/danielfdickinson/perfectionist-dfd/commit/b36ef0fc144d77ca9db5272eb7f3390058c7cbf8) ([Daniel F. Dickinson](mailto:dfdpublic@wildtechgarden.ca))
+- [3.0.0-alpha.3-dev.1](https://github.com/danielfdickinson/perfectionist-dfd/commit/ebd90577c96150748308e000c140bfc4470db70a) ([Daniel F. Dickinson](mailto:dfdpublic@wildtechgarden.ca))
 - [Update CHANGELOG](https://github.com/danielfdickinson/perfectionist-dfd/commit/d00e9676f85ed92d9863c1557cd3d55c85803c20) ([Daniel F. Dickinson](mailto:dfdpublic@wildtechgarden.ca))
 - [Remove completed TODO item \(8.x API wrapper\)](https://github.com/danielfdickinson/perfectionist-dfd/commit/2ad0ba5e0fda920e922f357b4b8670a7bd7bcf70) ([Daniel F. Dickinson](mailto:dfdpublic@wildtechgarden.ca))
 - [Remove always dead code](https://github.com/danielfdickinson/perfectionist-dfd/commit/e69fc3638c15428027978e238878840997f04d0e) ([Daniel F. Dickinson](mailto:dfdpublic@wildtechgarden.ca))
-- [Prepare for 3.0.0-alpha.1 \(pre-release\)](https://github.com/danielfdickinson/perfectionist-dfd/commit/645387fd6b878520153bca45cb052f967be5b8eb) ([Daniel F. Dickinson](mailto:dfdpublic@wildtechgarden.ca))
-- [Update package-lock.json to v2](https://github.com/danielfdickinson/perfectionist-dfd/commit/cc0d55495ac575d66c1b5ac0f3015811ab8bcb6f) ([Daniel F. Dickinson](mailto:dfdpublic@wildtechgarden.ca))
-- [+12 more](https://github.com/danielfdickinson/perfectionist-dfd/compare/v2.4.2...v3.0.0-alpha.2)
+- [+14 more](https://github.com/danielfdickinson/perfectionist-dfd/compare/v2.4.2...v3.0.0-alpha.3-dev.1)
 
 ### v2.4.2 (2022-04-03)
 
@@ -58,7 +58,7 @@
 
 - [#33](https://github.com/danielfdickinson/perfectionist-dfd/pull/33) Update ava to version 0.16.0 🚀 ([greenkeeperio-bot](mailto:support@greenkeeper.io))
 
-#### Commits to pr-fix-publish-tagging-latest-on-prerelease
+#### Commits to pr-default-publish-devel
 
 - [Update changelog.](https://github.com/danielfdickinson/perfectionist-dfd/commit/d3515b27a2dca53193963626e1a0f42d41b74435) ([Ben Briggs](mailto:beneb.info@gmail.com))
 - [Add options which format hex colours.](https://github.com/danielfdickinson/perfectionist-dfd/commit/ddef43b9841f9162e3c495263894f7cd9fa1acea) ([Ivan Sosnin](mailto:vansosnin@gmail.com))
@@ -78,7 +78,7 @@
 
 - [#25](https://github.com/danielfdickinson/perfectionist-dfd/pull/25) Ignore commas inside quotes. Fixes \#24 ([Rob Garrison](mailto:wowmotty@gmail.com))
 
-#### Commits to pr-fix-publish-tagging-latest-on-prerelease
+#### Commits to pr-default-publish-devel
 
 - [Update changelog.](https://github.com/danielfdickinson/perfectionist-dfd/commit/6d449e68f7e97e9f342186a2452c8a4c2e149960) ([Ben Briggs](mailto:beneb.info@gmail.com))
 - [Update CI environment and babel.](https://github.com/danielfdickinson/perfectionist-dfd/commit/56aaf727eb59610412d7c8b1daead8b20a923899) ([Ben Briggs](mailto:beneb.info@gmail.com))
@@ -101,7 +101,7 @@
 
 - [#20](https://github.com/danielfdickinson/perfectionist-dfd/pull/20) add Atom plugin to readme ([Sindre Sorhus](mailto:sindresorhus@gmail.com))
 
-#### Commits to pr-fix-publish-tagging-latest-on-prerelease
+#### Commits to pr-default-publish-devel
 
 - [Update changelog.](https://github.com/danielfdickinson/perfectionist-dfd/commit/5aba30360372c1ef0eb41ed11ccf0690451f69c1) ([Ben Briggs](mailto:beneb.info@gmail.com))
 - [Add scss syntax. Fixes \#15.](https://github.com/danielfdickinson/perfectionist-dfd/commit/9571fe70dd35e6ac1c58288474cc80179e400c7b) ([Ben Briggs](mailto:beneb.info@gmail.com))
@@ -115,7 +115,7 @@
 
 - [#17](https://github.com/danielfdickinson/perfectionist-dfd/pull/17) Use PostCSS 5.0 API ([一丝](mailto:percyley@qq.com))
 
-#### Commits to pr-fix-publish-tagging-latest-on-prerelease
+#### Commits to pr-default-publish-devel
 
 - [Update changelog.](https://github.com/danielfdickinson/perfectionist-dfd/commit/4c26bb79ca1ca0a0aa1484c6bbea3110628400b9) ([Ben Briggs](mailto:beneb.info@gmail.com))
 - [Add a note in the readme about the Sublime Text plugin.](https://github.com/danielfdickinson/perfectionist-dfd/commit/b321d8b183fcfa7e8172fcaeee13643ac5ae8c9b) ([Ben Briggs](mailto:beneb.info@gmail.com))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### v3.0.0-alpha.2 (2022-04-03)
 
+- [Update CHANGELOG](https://github.com/danielfdickinson/perfectionist-dfd/commit/d00e9676f85ed92d9863c1557cd3d55c85803c20) ([Daniel F. Dickinson](mailto:dfdpublic@wildtechgarden.ca))
 - [Remove completed TODO item \(8.x API wrapper\)](https://github.com/danielfdickinson/perfectionist-dfd/commit/2ad0ba5e0fda920e922f357b4b8670a7bd7bcf70) ([Daniel F. Dickinson](mailto:dfdpublic@wildtechgarden.ca))
 - [Remove always dead code](https://github.com/danielfdickinson/perfectionist-dfd/commit/e69fc3638c15428027978e238878840997f04d0e) ([Daniel F. Dickinson](mailto:dfdpublic@wildtechgarden.ca))
 - [Prepare for 3.0.0-alpha.1 \(pre-release\)](https://github.com/danielfdickinson/perfectionist-dfd/commit/645387fd6b878520153bca45cb052f967be5b8eb) ([Daniel F. Dickinson](mailto:dfdpublic@wildtechgarden.ca))
 - [Update package-lock.json to v2](https://github.com/danielfdickinson/perfectionist-dfd/commit/cc0d55495ac575d66c1b5ac0f3015811ab8bcb6f) ([Daniel F. Dickinson](mailto:dfdpublic@wildtechgarden.ca))
-- [Add and use package clean-publish](https://github.com/danielfdickinson/perfectionist-dfd/commit/ab81064e415136c88fc3abc8ffe1a8fd4572ddda) ([Daniel F. Dickinson](mailto:dfdpublic@wildtechgarden.ca))
-- [+11 more](https://github.com/danielfdickinson/perfectionist-dfd/compare/v2.4.2...v3.0.0-alpha.2)
+- [+12 more](https://github.com/danielfdickinson/perfectionist-dfd/compare/v2.4.2...v3.0.0-alpha.2)
 
 ### v2.4.2 (2022-04-03)
 
@@ -58,7 +58,7 @@
 
 - [#33](https://github.com/danielfdickinson/perfectionist-dfd/pull/33) Update ava to version 0.16.0 🚀 ([greenkeeperio-bot](mailto:support@greenkeeper.io))
 
-#### Commits to pr-remove-broken-clean-publish
+#### Commits to pr-fix-publish-tagging-latest-on-prerelease
 
 - [Update changelog.](https://github.com/danielfdickinson/perfectionist-dfd/commit/d3515b27a2dca53193963626e1a0f42d41b74435) ([Ben Briggs](mailto:beneb.info@gmail.com))
 - [Add options which format hex colours.](https://github.com/danielfdickinson/perfectionist-dfd/commit/ddef43b9841f9162e3c495263894f7cd9fa1acea) ([Ivan Sosnin](mailto:vansosnin@gmail.com))
@@ -78,7 +78,7 @@
 
 - [#25](https://github.com/danielfdickinson/perfectionist-dfd/pull/25) Ignore commas inside quotes. Fixes \#24 ([Rob Garrison](mailto:wowmotty@gmail.com))
 
-#### Commits to pr-remove-broken-clean-publish
+#### Commits to pr-fix-publish-tagging-latest-on-prerelease
 
 - [Update changelog.](https://github.com/danielfdickinson/perfectionist-dfd/commit/6d449e68f7e97e9f342186a2452c8a4c2e149960) ([Ben Briggs](mailto:beneb.info@gmail.com))
 - [Update CI environment and babel.](https://github.com/danielfdickinson/perfectionist-dfd/commit/56aaf727eb59610412d7c8b1daead8b20a923899) ([Ben Briggs](mailto:beneb.info@gmail.com))
@@ -101,7 +101,7 @@
 
 - [#20](https://github.com/danielfdickinson/perfectionist-dfd/pull/20) add Atom plugin to readme ([Sindre Sorhus](mailto:sindresorhus@gmail.com))
 
-#### Commits to pr-remove-broken-clean-publish
+#### Commits to pr-fix-publish-tagging-latest-on-prerelease
 
 - [Update changelog.](https://github.com/danielfdickinson/perfectionist-dfd/commit/5aba30360372c1ef0eb41ed11ccf0690451f69c1) ([Ben Briggs](mailto:beneb.info@gmail.com))
 - [Add scss syntax. Fixes \#15.](https://github.com/danielfdickinson/perfectionist-dfd/commit/9571fe70dd35e6ac1c58288474cc80179e400c7b) ([Ben Briggs](mailto:beneb.info@gmail.com))
@@ -115,7 +115,7 @@
 
 - [#17](https://github.com/danielfdickinson/perfectionist-dfd/pull/17) Use PostCSS 5.0 API ([一丝](mailto:percyley@qq.com))
 
-#### Commits to pr-remove-broken-clean-publish
+#### Commits to pr-fix-publish-tagging-latest-on-prerelease
 
 - [Update changelog.](https://github.com/danielfdickinson/perfectionist-dfd/commit/4c26bb79ca1ca0a0aa1484c6bbea3110628400b9) ([Ben Briggs](mailto:beneb.info@gmail.com))
 - [Add a note in the readme about the Sublime Text plugin.](https://github.com/danielfdickinson/perfectionist-dfd/commit/b321d8b183fcfa7e8172fcaeee13643ac5ae8c9b) ([Ben Briggs](mailto:beneb.info@gmail.com))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "perfectionist-dfd",
-  "version": "3.0.0-alpha.2",
+  "version": "3.0.0-alpha.3-dev.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "perfectionist-dfd",
-  "version": "3.0.0-alpha.3-dev.1",
+  "version": "3.0.0-alpha.3-dev.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perfectionist-dfd",
-  "version": "3.0.0-alpha.2",
+  "version": "3.0.0-alpha.3-dev.1",
   "description": "Beautify and/or normalize CSS files. Fork and update of a fork and update of an archived project.",
   "type": "commonjs",
   "main": "dist/perfectionist-dfd.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perfectionist-dfd",
-  "version": "3.0.0-alpha.3-dev.1",
+  "version": "3.0.0-alpha.3-dev.2",
   "description": "Beautify and/or normalize CSS files. Fork and update of a fork and update of an archived project.",
   "type": "commonjs",
   "main": "dist/perfectionist-dfd.min.js",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "LICENSE",
     "README.md"
   ],
+  "publishConfig": {
+    "tag": "devel"
+  },
   "scripts": {
     "coverage": "rollup -c && cross-env NODE_ENV=test c8 ava ./__tests__/*.mjs",
     "lint": "eslint src --ext .mjs --ext .js",


### PR DESCRIPTION
In order to make sure we don't accidentally make a prerelease version have the 'latest' tag and therefore be the version end-users get by default, make the default tag 'devel'.