### PR TITLE
3.0.1-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perfectionist-dfd",
-  "version": "3.0.1-DEV",
+  "version": "3.0.1-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "perfectionist-dfd",
-      "version": "3.0.1-DEV",
+      "version": "3.0.1-beta.1",
       "license": "MIT",
       "dependencies": {
         "defined": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perfectionist-dfd",
-  "version": "3.0.1-DEV",
+  "version": "3.0.1-beta.1",
   "description": "Beautify and/or normalize CSS files. Fork and update of a fork and update of an archived project.",
   "type": "commonjs",
   "main": "dist/perfectionist-dfd.min.js",


### PR DESCRIPTION
Make the recent security update a pre-release (beta, tagged as devel on npmjs.org) so it can possibly be more widely tested.