### PR TITLE
Add Node 18 to CI instead of 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: ['16', '17']
+        node-version: ['16', '18']
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
17 is an unstable version, so now that 18 is out for while,
update the tests to add Node 18 in place of Node 17

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>